### PR TITLE
Update wpautoload.php

### DIFF
--- a/wpautoload.php
+++ b/wpautoload.php
@@ -14,13 +14,14 @@ use WPPunk\Autoload\Cache;
 use Composer\Json\JsonFile;
 use WPPunk\Autoload\Autoload;
 
-$file    = new JsonFile( Factory::getComposerFile() );
+$baseDir = dirname( __FILE__, 4 );
+$file    = new JsonFile( $baseDir . '/' . Factory::getComposerFile() );
 $content = $file->read();
 if ( empty( $content['extra']['wp-autoload'] ) ) {
 	return;
 }
 
-$dir   = dirname( Factory::getComposerFile() ) . '/';
+$dir   = $baseDir . '/';
 $cache = new Cache();
 
 foreach ( $content['extra']['wp-autoload'] as $prefix => $folder ) {


### PR DESCRIPTION
use absolute path instead of relative path to fix composer.json not found